### PR TITLE
replace exec with execfile

### DIFF
--- a/src/escape-shell-arg.js
+++ b/src/escape-shell-arg.js
@@ -1,8 +1,0 @@
-// Use greedy quotes to escape shell arguments.
-//
-// We are also relying on sanitize-name, so don't pass anything that hasn't been
-// through sanitize-name.
-
-module.exports = function escapeShellArg (arg) {
-  return '"' + arg.toString().replace(/(["\s'$`\\])/g, '\\$1') + '"'
-}

--- a/src/ipfs-data.js
+++ b/src/ipfs-data.js
@@ -1,4 +1,4 @@
-const exec = require('child_process').exec
+const execFile = require('child_process').execFile
 const sanitize = require('./sanitize-name')
 const escapeShellArg = require('./escape-shell-arg')
 
@@ -19,7 +19,7 @@ module.exports = class Data {
       if (!name.match(/[a-z0-9]+/gi)) {
         return reject('invalid argument')
       }
-      exec(`ipfs cat /ipfs/${name}/parcel.aframe`, (err, stdout, stderr) => {
+      execFile('ipfs', ['cat', `/ipfs/${name}/parcel.aframe`], (err, stdout, stderr) => {
         if (err) return reject(stderr)
         return resolve(stdout)
       })
@@ -30,7 +30,7 @@ module.exports = class Data {
       if (!name.match(/[a-z0-9]+/gi)) {
         return reject('invalid argument')
       }
-      exec(`ipfs cat /ipfs/${name}/scene.json`, (err, stdout, stderr) => {
+      execFile('ipfs', ['cat', `/ipfs/${name}/scene.json`], (err, stdout, stderr) => {
         if (err) return reject(stderr)
         return resolve(stdout)
       })

--- a/src/ipfs-reupload.js
+++ b/src/ipfs-reupload.js
@@ -1,7 +1,7 @@
 const tempy = require('tempy')
 const fs = require('fs')
 const path = require('path')
-const exec = require('child_process').exec
+const execFile = require('child_process').execFile
 const escapeShellArg = require('./escape-shell-arg')
 const glob = require('glob')
 const zipName = 'model.zip'
@@ -22,7 +22,7 @@ class Bundle {
 
     return new Promise(
       (resolve, reject) => {
-        exec(`curl ${escapeShellArg(url)} -o ${this.zipfile}`, (err, stdout, stderr) => {
+        execFile('curl', [url, '-o', this.zipfile], (err, stdout, stderr) => {
           if (err) {
             reject(err)
             return
@@ -55,8 +55,7 @@ class Bundle {
             resolve(this)
           })
         }
-
-        exec(`unzip ${zipName}`, { cwd: this.directory }, (err, stdout, stderr) => {
+        execFile('unzip', [zipName], { cwd: this.directory }, (err, stdout, stderr) => {
           if (err) {
             reject(err)
             return
@@ -74,7 +73,7 @@ class Bundle {
       (resolve, reject) => {
         console.log(`ipfs add -r ${path.join(this.directory, './*')}`)
 
-        exec(`ipfs add -w -r ${path.join(this.directory, './*')}`, (err, stdout, stderr) => {
+        execFile('ipfs',['add', '-w', '-r', path.join(this.directory, './*')], (err, stdout, stderr) => {
           if (err) {
             reject(err)
             return

--- a/src/ipfs-upload.js
+++ b/src/ipfs-upload.js
@@ -1,7 +1,7 @@
 const tempy = require('tempy')
 const fs = require('fs')
 const path = require('path')
-const exec = require('child_process').exec
+const execFile = require('child_process').execFile
 const mkdirp = require('mkdirp')
 
 class Bundle {
@@ -42,7 +42,7 @@ class Bundle {
       (resolve, reject) => {
         console.log(`ipfs add -r ${path.join(this.directory, './*')}`)
 
-        exec(`ipfs add -w -r ${path.join(this.directory, './*')}`, (err, stdout, stderr) => {
+        execFile('ipfs', ['add', '-w', '-r', path.join(this.directory, './*')], (err, stdout, stderr) => {
           if (err) {
             reject(err)
             return


### PR DESCRIPTION
when executing the IPFS commands right now is using exec, with exec you can add vulnerabilities likes command injection. in this case I replaced all the exec with execFile, also execFile is more performant because it wont spawn a shell every time that we call IPFS.